### PR TITLE
Release 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2020-08-18
+
+- Added *IConfigsAdder* interface to separate the contract behaviour when an object wants to add configs without needing to rely on the *ConfigsProvider*
+
 ## [0.6.0] - 2020-07-28
 
 - Added *ConfigsProvider* to provide the loaded google sheet configs

--- a/Runtime/ConfigsProvider.cs
+++ b/Runtime/ConfigsProvider.cs
@@ -33,9 +33,29 @@ namespace GameLovers.GoogleSheetImporter
 		/// </summary>
 		IReadOnlyDictionary<int, T> GetConfigsDictionary<T>();
 	}
+
+	/// <inheritdoc />
+	/// <remarks>
+	/// Extends the <see cref="IConfigsProvider"/> behaviour by allowing it to add configs to the provider
+	/// </remarks>
+	public interface IConfigsAdder : IConfigsProvider
+	{
+		/// <summary>
+		/// Adds the given unique single <paramref name="config"/> to the container.
+		/// Use the <seealso cref="IConfigsProvider.GetSingleConfig{T}"/> to retrieve it.
+		/// </summary>
+		void AddSingletonConfig<T>(T config);
+
+		/// <summary>
+		/// Adds the given <paramref name="configList"/> to the container.
+		/// The configuration will use the given <paramref name="referenceIdResolver"/> to map each config to it's defined id.
+		/// Use the <seealso cref="IConfigsProvider.GetConfig{T}"/> to retrieve it.
+		/// </summary>
+		void AddConfigs<T>(Func<T, int> referenceIdResolver, IList<T> configList) where T : struct;
+	}
 	
 	/// <inheritdoc />
-	public class ConfigsProvider : IConfigsProvider
+	public class ConfigsProvider : IConfigsAdder
 	{
 		private const int _singleConfigId = 0;
 		
@@ -65,20 +85,13 @@ namespace GameLovers.GoogleSheetImporter
 			return _configs[typeof(T)] as IReadOnlyDictionary<int, T>;
 		}
 
-		/// <summary>
-		/// Adds the given unique single <paramref name="config"/> to the container.
-		/// Use the <seealso cref="GetSingletonConfig{T}"/> to retrieve it.
-		/// </summary>
+		/// <inheritdoc />
 		public void AddSingletonConfig<T>(T config)
 		{
 			_configs.Add(typeof(T), new ReadOnlyDictionary<int, T>(new Dictionary<int, T> {{ _singleConfigId, config }}));
 		}
 
-		/// <summary>
-		/// Adds the given <paramref name="configList"/> to the container.
-		/// The configuration will use the given <paramref name="referenceIdResolver"/> to map each config to it's defined id.
-		/// Use the <seealso cref="GetConfig{T}"/> to retrieve it.
-		/// </summary>
+		/// <inheritdoc />
 		public void AddConfigs<T>(Func<T, int> referenceIdResolver, IList<T> configList) where T : struct
 		{
 			var dictionary = new Dictionary<int, T>();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.gamelovers.googlesheetimporter",
   "displayName": "GoogleSheet Importer",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "unity": "2019.3",
   "description": "This package provides a tool to import GoogleSheet data into ScriptableObject persistent config data.\n\nTo help configure the GoogleSheet Import data you need to create a configuration ScriptableObject by:\n- Right Click on the Project View > Create > ScriptableObjects > Editor > GoogleSheetImporter.\n- You can import all the GoogleSheet data without a ScriptableObject by clicking in Tools > Import Google Sheet Data",
   "type": "tool",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,6 @@
   "description": "This package provides a tool to import GoogleSheet data into ScriptableObject persistent config data.\n\nTo help configure the GoogleSheet Import data you need to create a configuration ScriptableObject by:\n- Right Click on the Project View > Create > ScriptableObjects > Editor > GoogleSheetImporter.\n- You can import all the GoogleSheet data without a ScriptableObject by clicking in Tools > Import Google Sheet Data",
   "type": "tool",
   "dependencies": {
-    "com.unity.nuget.newtonsoft-json": "2.0.0-preview"
+    "com.unity.nuget.newtonsoft-json": "2.0.0"
   }
 }


### PR DESCRIPTION
- Added *IConfigsAdder* interface to separate the contract behaviour when an object wants to add configs without needing to rely on the *ConfigsProvider*